### PR TITLE
Time layer + flag to skip

### DIFF
--- a/pyeo/apps/change_detection/rolling_composite_s2_change_detection.py
+++ b/pyeo/apps/change_detection/rolling_composite_s2_change_detection.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
             pyeo.preprocess_sen2_images(composite_l2_image_dir, composite_merged_dir, composite_l1_image_dir,
                                         cloud_certainty_threshold, epsg=epsg, buffer_size=5)
         log.info("Building initial cloud-free composite")
-        pyeo.composite_directory(composite_merged_dir, composite_dir)
+        pyeo.composite_directory(composite_merged_dir, composite_dir, generate_date_images=True)
 
     # Query and download all images since last composite
     if args.do_download or do_all:
@@ -179,7 +179,8 @@ if __name__ == "__main__":
             log.info("Updating composite")
             new_composite_path = os.path.join(
                 composite_dir, "composite_{}.tif".format(pyeo.get_sen_2_image_timestamp(os.path.basename(image))))
-            pyeo.composite_images_with_mask((latest_composite_path, new_image_path), new_composite_path)
+            pyeo.composite_images_with_mask(
+                (latest_composite_path, new_image_path), new_composite_path, generate_date_image=True)
             latest_composite_path = new_composite_path
 
     log.info("***PROCESSING END***")

--- a/pyeo/apps/change_detection/rolling_composite_s2_change_detection.py
+++ b/pyeo/apps/change_detection/rolling_composite_s2_change_detection.py
@@ -51,6 +51,8 @@ if __name__ == "__main__":
     parser.add_argument('-u', '--update', dest='do_update', action='store_true', default=False)
     parser.add_argument('-r', '--remove', dest='do_delete', action='store_true', default=False)
 
+    parser.add_argument('--skip_prob_image', dest="skip_prob_image", action="store_true", default=False)
+
     args = parser.parse_args()
 
     # If any processing step args are present, do not assume that we want to do all steps
@@ -88,6 +90,9 @@ if __name__ == "__main__":
     composite_l1_image_dir = os.path.join(project_root, r"composite/L1")
     composite_l2_image_dir = os.path.join(project_root, r"composite/L2")
     composite_merged_dir = os.path.join(project_root, r"composite/merged")
+
+    if args.skip_prob_image:
+        probability_image_dir = None
 
     if args.start_date == "LATEST":
         # This isn't nice, but returns the yyyymmdd string of the latest stacked image

--- a/pyeo/apps/subprocessing/composite_directory.py
+++ b/pyeo/apps/subprocessing/composite_directory.py
@@ -30,6 +30,8 @@ if __name__ == "__main__":
                         help="Path to logfile (optional)")
     parser.add_argument('-r', '--remask', dest='mask_path', action="store",
                         help="If present, remask the files using an image at model_path")
+    parser.add_argument('-d', '--dates_image', dest="generate_dates_image", action = "store_true",
+                        help="If present, will build a single-layer .tif of dates of pixels in composite")
     args = parser.parse_args()
 
     comp_dir = args.in_dir
@@ -45,4 +47,4 @@ if __name__ == "__main__":
         for image in [os.path.join(os.path.dirname(comp_dir), file) for file in os.listdir(comp_dir)]:
             pyeo.core.create_mask_from_model(image, args.mask_path)
 
-    pyeo.core.composite_directory(comp_dir, args.out_path)
+    pyeo.core.composite_directory(comp_dir, args.out_path, generate_date_images=args.generate_dates_image)

--- a/pyeo/core.py
+++ b/pyeo/core.py
@@ -722,8 +722,6 @@ def get_image_acquisition_time(image_name):
         return None
 
 
-
-
 def get_preceding_image_path(target_image_name, search_dir):
     """Gets the path to the image in search_dir preceding the image called image_name"""
     target_time = get_image_acquisition_time(target_image_name)
@@ -736,14 +734,12 @@ def get_preceding_image_path(target_image_name, search_dir):
     raise FileNotFoundError("No image older than {}".format(target_image_name))
 
 
-
 def is_tif(image_string):
     """Returns True if image ends with .tif"""
     if image_string.endswith(".tif"):
         return True
     else:
         return False
-
 
 
 def open_dataset_from_safe(safe_file_path, band, resolution = "10m"):
@@ -1070,6 +1066,7 @@ def composite_images_with_mask(in_raster_path_list, composite_out_path, format="
             # Gets timestamp as integer in form yyyymmdd
             date = np.uint32(get_sen_2_image_timestamp(in_raster.GetFileList()[0]).split("T")[0])
             dates_view[np.logical_not(in_masked.mask[0, ...])] = date
+            log.debug(dates_view.max())
             dates_view = None
 
         # Deallocate

--- a/pyeo/core.py
+++ b/pyeo/core.py
@@ -1066,7 +1066,6 @@ def composite_images_with_mask(in_raster_path_list, composite_out_path, format="
             # Gets timestamp as integer in form yyyymmdd
             date = np.uint32(get_sen_2_image_timestamp(in_raster.GetFileList()[0]).split("T")[0])
             dates_view[np.logical_not(in_masked.mask[0, ...])] = date
-            log.debug(dates_view.max())
             dates_view = None
 
         # Deallocate

--- a/pyeo/tests/real_data_tests.py
+++ b/pyeo/tests/real_data_tests.py
@@ -119,7 +119,7 @@ def test_composite_images_with_mask():
     test_data = [r"test_data/S2A_MSIL2A_20180329T171921_N0206_R012_T13QFB_20180329T221746.tif",
                  r"test_data/S2B_MSIL2A_20180103T172709_N0206_R012_T13QFB_20180103T192359.tif"]
     out_file = r"test_outputs/composite_test.tif"
-    pyeo.composite_images_with_mask(test_data, out_file)
+    pyeo.composite_images_with_mask(test_data, out_file, generate_date_image=True)
     image = gdal.Open("test_outputs/composite_test.tif")
     assert image
     image_array = image.GetVirtualMemArray()
@@ -331,7 +331,7 @@ def test_composite_off_by_one():
     except FileNotFoundError:
         pass
     os.mkdir("test_outputs/off_by_one_error")
-    pyeo.composite_directory("test_data/off_by_one", "test_outputs/off_by_one_error")
+    pyeo.composite_directory("test_data/off_by_one", "test_outputs/off_by_one_error",generate_date_images=True)
 
 
 def test_mask_closure():


### PR DESCRIPTION
There's now a flag in pyeo.core.composite_images_with_mask to create a date image as attached. It will be built in the same folder as the composite, with _date.tif appended to the filename.
It's a single-layer geotiff, with each pixel containing the date in the format yyyymmdd. Unassigned pixels are value 0.

Also:Added --skip_prob_image as a flag to rolling_composite: this allows users of rolling_composite_change_detection to not build the large and unwieldy probability rasters.