### PR TITLE
Dataspace search error catch

### DIFF
--- a/pyeo/queries_and_downloads.py
+++ b/pyeo/queries_and_downloads.py
@@ -168,11 +168,14 @@ def query_dataspace_by_polygon(
     response = requests.get(request_string)
     if response.status_code == 200:
         response = response.json()["features"]
-        # log.info(json.dumps(response, indent=4))
-        # sys.exit(1)
         response_dataframe = pd.DataFrame.from_dict(response)
+        if response_dataframe.empty == True:
+            log.error("There were no products returned in the search query and the CDSE API is responding correctly. Expand the query start and end dates and/or increase cloud cover tolerance in the `ini`")
+            sys.exit(1)
+
         response_dataframe = pd.DataFrame.from_records(response_dataframe["properties"])
         return response_dataframe
+    
     elif response.status_code == 401:
         log.error("Dataspace returned a 401 HTTP Status Code")
         log.error("Which means that user credentials for the Copernicus Dataspace Ecosystem are incorrect.")

--- a/pyeo/run_acd_national.py
+++ b/pyeo/run_acd_national.py
@@ -37,5 +37,4 @@ if __name__ == "__main__":
     # if run from terminal, __name__ becomes "__main__"
     # sys.argv[0] is the name of the python script, e.g. acd_national.py
 
-    # I.R. Changed as a list was getting passed but a single config_path string is expected by the receiving functions
     acd_national.automatic_change_detection_national(sys.argv[1])


### PR DESCRIPTION
The problem: 
`UnboundLocalError: local variable 'dataspace_change_products_all' referenced before assignment`

The cause: 
`query_dataspace_by_polygon` was returning blank if no products matched the query (rightfully so), this meant that the line `response_dataframe = pd.DataFrame.from_records(response_dataframe["properties"])` could not succeed and so `dataspace_change_products_all` could not be created.

The double-checking: 
- CDSE API returned a Status Code of `200`, meaning that the API was responding as expected.
- The search query was for a short time period (`start_date=20230331` and `end_date=20230412`) and a low `cloud_cover` threshold of 25%, therefore no images matched these requirements.

The solution: 
added a check that if no products are in `response_dataframe`, then print a verbose error to the log and `sys.exit(1)`.
