### PR TITLE
Jasmin bug fixes - dropping duplicate acquisition dates before image download

### DIFF
--- a/pyeo/apps/change_detection/make_composite.py
+++ b/pyeo/apps/change_detection/make_composite.py
@@ -1079,10 +1079,6 @@ def create_composite(config_path, tile_id="None"):
 
 if __name__ == "__main__":
 
-    # Geopandas can throw an error with the proj installation if multiple subdirectories called proj are within the environment directory:
-    #    PROJ: internal_proj_identify: /home/h/hb91/miniconda3/envs/pyeo_env/share/proj/proj.db lacks DATABASE.LAYOUT.VERSION.MAJOR / DATABASE.LAYOUT.VERSION.MINOR metadata. It comes from another PROJ installation.
-    print(os.environ["PROJ_LIB"])
-
     # Reading in config file
     parser = argparse.ArgumentParser(
         description="Downloads and preprocesses Sentinel 2 images into median composites."

--- a/pyeo/queries_and_downloads.py
+++ b/pyeo/queries_and_downloads.py
@@ -108,12 +108,15 @@ from pyeo.filesystem_utilities import (check_for_invalid_l1_data,
                                          check_for_invalid_l2_data,
                                          get_sen_2_image_tile)
 from requests import Request
-# fix an issue with backwards incompatibility of the sentinelhub library
+# fix an issue with backwards incompatibility of the sentinelhub library from v3.9.1 onwards
 import sentinelhub
-if sentinelhub.__version__ > 9.3.0:
+hubversion = sentinelhub.__version__.split(".")
+if (int(hubversion[0]) > 3) or \
+    (int(hubversion[0]) == 3 and int(hubversion[1]) > 9) or \
+    (int(hubversion[0]) == 3 and int(hubversion[1]) == 9 and int(hubversion[2]) > 0):
     from sentinelhub.aws.request import download_safe_format
 else:
-    from sentinelhub.data_request import download_safe_format #OLD pre-v9.3.1
+    from sentinelhub.data_request import download_safe_format
 
 from sentinelsat import SentinelAPI, geojson_to_wkt, read_geojson
 

--- a/pyeo/queries_and_downloads.py
+++ b/pyeo/queries_and_downloads.py
@@ -108,7 +108,13 @@ from pyeo.filesystem_utilities import (check_for_invalid_l1_data,
                                          check_for_invalid_l2_data,
                                          get_sen_2_image_tile)
 from requests import Request
-from sentinelhub.data_request import download_safe_format
+# fix an issue with backwards incompatibility of the sentinelhub library
+import sentinelhub
+if sentinelhub.__version__ > 9.3.0:
+    from sentinelhub.aws.request import download_safe_format
+else:
+    from sentinelhub.data_request import download_safe_format #OLD pre-v9.3.1
+
 from sentinelsat import SentinelAPI, geojson_to_wkt, read_geojson
 
 log = logging.getLogger("pyeo")

--- a/pyeo/queries_and_downloads.py
+++ b/pyeo/queries_and_downloads.py
@@ -35,6 +35,16 @@ The only download source currently provided is via the Copernicus Dataspace Ecos
     Users do not need to be registered with the CDSE to query images, but `pyeo` expects the user to have provided a valid username and password. 
     The main change from SciHub to CDSE is that Sentinel-2 products are no longer archived beyond a certain time-frame, i.e. the products in the CDSE are always online.
 
+    Attributes for a query:
+      ['collection', 'status', 'license', 'productIdentifier',
+      'parentIdentifier', 'title', 'description', 'organisationName',
+      'startDate', 'completionDate', 'productType', 'processingLevel',
+      'platform', 'instrument', 'resolution', 'sensorMode', 'orbitNumber',
+      'quicklook', 'thumbnail', 'updated', 'published', 'snowCover',
+      'cloudCover', 'gmlgeometry', 'centroid', 'orbitDirection', 'timeliness',
+      'relativeOrbitNumber', 'processingBaseline', 'missionTakeId',
+      'services', 'links'],
+
 Legacy Download Sources
 -----------------------
 There are three other *legacy* download sources which this library no longer supports as they are deprecated in favour of the now active CDSE.

--- a/pyeo/raster_manipulation.py
+++ b/pyeo/raster_manipulation.py
@@ -3136,8 +3136,12 @@ def apply_processing_baseline_offset_correction_to_tiff_file_directory(
 
     log.info(f"Radiometric offset correction if processing_baseline > 0400 in" + \
              " directory: {in_tif_directory}")
-    log.info("NOTE: Processing baseline in the file names will be set to \"A0400\"" + \
+    log.info("NOTE: Processing baseline in the file names will be set to e.g. \"A400\"" + \
              " if correction has been applied.")
+    log.info("NOTE: Processing baseline 9999 for some L2A products originates from "+\
+             " ESA Cloud.Ferro and not from the Copernicus Data Space Ecosystem."+\
+             " These will be skipped.\n"+\
+             " See https://documentation.dataspace.copernicus.eu/Data/Sentinel2.html")
 
     image_files = [
         f
@@ -3154,7 +3158,9 @@ def apply_processing_baseline_offset_correction_to_tiff_file_directory(
         log.info(f"File: {f}, Baseline: {get_processing_baseline(f)}")
         if get_processing_baseline(f)[0] == "A":
             log.info(f"Offset already applied - file marked as: {get_processing_baseline(f)}")
-        if get_processing_baseline(f)[0] != "A" and (int(get_processing_baseline(f)[1:]) >= 400): # in ["0400", "0509"]:
+        if get_processing_baseline(f)[0] != "A" and \
+            (int(get_processing_baseline(f)[1:]) != 9999 and \            
+            (int(get_processing_baseline(f)[1:]) >= 400): # in ["0400", "0509"]:
             in_raster_path = os.path.join(in_tif_directory, f)
             log.info(f"Offsetting file: {f}")
             log.info(f'Full file path: {in_raster_path}')

--- a/pyeo/raster_manipulation.py
+++ b/pyeo/raster_manipulation.py
@@ -3159,8 +3159,8 @@ def apply_processing_baseline_offset_correction_to_tiff_file_directory(
         if get_processing_baseline(f)[0] == "A":
             log.info(f"Offset already applied - file marked as: {get_processing_baseline(f)}")
         if get_processing_baseline(f)[0] != "A" and \
-            (int(get_processing_baseline(f)[1:]) != 9999 and \            
-            (int(get_processing_baseline(f)[1:]) >= 400): # in ["0400", "0509"]:
+            (int(get_processing_baseline(f)) != 9999 and \
+            int(get_processing_baseline(f)) >= 400): # in ["0400", "0509"]:
             in_raster_path = os.path.join(in_tif_directory, f)
             log.info(f"Offsetting file: {f}")
             log.info(f'Full file path: {in_raster_path}')

--- a/pyeo/raster_manipulation.py
+++ b/pyeo/raster_manipulation.py
@@ -2943,6 +2943,10 @@ def apply_processing_baseline_0400_offset_correction_to_tiff_file_directory(
     """
     Offsets data within selected bands from a directory of stacked raster files
     Overwrites original file - option to save a backup copy.
+    
+    WARNING: apply_processing_baseline_0400_offset_correction_to_tiff_file_directory()
+        will be depracated.
+        Use apply_processing_baseline_offset_correction_to_tiff_file_directory() instead
 
     Parameters
     ----------
@@ -2991,6 +2995,9 @@ def apply_processing_baseline_0400_offset_correction_to_tiff_file_directory(
              " directory: {in_tif_directory}")
     log.info("NOTE: Processing baseline in the file names will be set to \"A0400\"" + \
              " if correction has been applied.")
+    log.warning("WARNING: apply_processing_baseline_0400_offset_correction_to_tiff_file_directory() " + \
+             "will be depracated. " + \
+             "Use apply_processing_baseline_offset_correction_to_tiff_file_directory() instead.")
 
     image_files = [
         f
@@ -3086,6 +3093,7 @@ def apply_processing_baseline_offset_correction_to_tiff_file_directory(
     bands_to_offset_index=[0, 1, 2, 3],
     BOA_ADD_OFFSET=-1000,
     backup_flag=False,
+    log = logging.getLogger(__name__)
 ):
     """
     Offsets data within selected bands from a directory of stacked raster files
@@ -3105,6 +3113,8 @@ def apply_processing_baseline_offset_correction_to_tiff_file_directory(
         Required offset per band (from xml information within L2A SAFE file directory)
     backup_flag : True/False
         If True leaves unoffset images with .backup extension in tif_directory
+    log : logger object
+        Directs logging output
 
     Returns
     -------
@@ -3124,9 +3134,10 @@ def apply_processing_baseline_offset_correction_to_tiff_file_directory(
     if not os.path.exists(out_tif_directory):
         os.mkdir(out_tif_directory)
 
-    log.info(
-        f"apply_processing_baseline_offset_correction_to_tiff_file_directory() running on: {in_tif_directory}"
-    )
+    log.info(f"Radiometric offset correction if processing_baseline > 0400 in" + \
+             " directory: {in_tif_directory}")
+    log.info("NOTE: Processing baseline in the file names will be set to \"A0400\"" + \
+             " if correction has been applied.")
 
     image_files = [
         f
@@ -3137,30 +3148,23 @@ def apply_processing_baseline_offset_correction_to_tiff_file_directory(
     # TODO: Force generated dtype to uint16 to save time and storage? Compatible with classifier?
     # Generate bands_to_offset_index from comparison of bands_to_offset labels in band.description
     # Read individual BOA_ADD_OFFSET value for each band from xml information in SAFE file root
-    # Use 'with TemporaryDirectory' pattern - Overwrite existing files with offset files by 'move'
     # Work out why offset files are larger (2GB from ~1GB)
 
     for f in image_files:
-        # print(f"File: {f}, Baseline: {get_processing_baseline(f)}")
         log.info(f"File: {f}, Baseline: {get_processing_baseline(f)}")
         if get_processing_baseline(f)[0] == "A":
-            # print(f"Offset already applied - file marked as: {get_processing_baseline(f)}")
             log.info(f"Offset already applied - file marked as: {get_processing_baseline(f)}")
-        # print(f'int(get_processing_baseline(f)[1:]): {int(get_processing_baseline(f)[1:])}')
         if get_processing_baseline(f)[0] != "A" and (int(get_processing_baseline(f)[1:]) >= 400): # in ["0400", "0509"]:
             in_raster_path = os.path.join(in_tif_directory, f)
-            # print(f"Offsetting file: {f}")
             log.info(f"Offsetting file: {f}")
-            # print(f"in_raster_path: {in_raster_path}")
-            log.info(f'in_raster_path: {in_raster_path}')
+            log.info(f'Full file path: {in_raster_path}')
             # Define temporary file destination for output
             out_temporary_raster_path = os.path.join(
                 out_tif_directory,
                 os.path.basename(f).split(".")[0] + "_offset_temp.tif",
             )
-            # print(f"out_temporary_raster_path: {out_temporary_raster_path}")
             log.info(f"out_temporary_raster_path: {out_temporary_raster_path}")
-            # Open data set
+            # Open dataset
             in_raster_ds = gdal.Open(in_raster_path, gdal.GA_Update)
             raster_band_count = in_raster_ds.RasterCount
             in_raster_array = in_raster_ds.GetVirtualMemArray()
@@ -3172,12 +3176,9 @@ def apply_processing_baseline_offset_correction_to_tiff_file_directory(
             out_temporary_raster_array = out_temporary_raster_ds.GetVirtualMemArray(
                 eAccess=gdal.GA_Update
             )
-            # out_temporary_raster_array[...] = in_raster_array[bands_to_offset_index, :,:] + BOA_ADD_OFFSET
 
-            # print(f"in_raster_array dtype: {in_raster_array.dtype}")
             log.info(f"in_raster_array dtype: {in_raster_array.dtype}")
             dtype_max = 10000  # np.iinfo(in_raster_array.dtype).max # upper bound for range clipping - should be > any likely pixel value
-            # print(f"in_raster_array dtype_max used: {dtype_max}")
             log.info(f"in_raster_array clipped to range of min: {-1 * BOA_ADD_OFFSET} and max: {dtype_max} then offset by: {BOA_ADD_OFFSET}")
 
             # Simple offset of all image bands
@@ -3190,16 +3191,8 @@ def apply_processing_baseline_offset_correction_to_tiff_file_directory(
                 + BOA_ADD_OFFSET
             )
 
-            #out_temporary_raster_array[...] = (
-            #   np.clip(
-            #        in_raster_array[bands_to_offset_index, :, :],
-            #        (-1 * BOA_ADD_OFFSET),
-            #        dtype_max,
-            #    )
-            #    + BOA_ADD_OFFSET
-            #)
-
-            # Untested: Improvement to offset just selected bands by label - for band specific offsetting if required
+            # Untested: Improvement to offset just selected bands by label 
+            #   - for band specific offsetting if required
             # out_raster_array[...] = in_raster_array[...]  # Copy over all data
             # for band_index in raster_band_count:
             #     band_in = in_raster_ds.GetRasterBand(band_index+1)
@@ -3214,22 +3207,26 @@ def apply_processing_baseline_offset_correction_to_tiff_file_directory(
             out_temporary_raster_ds = None
             in_raster_ds = None
 
-            # Backup original .tif file to .backup file (subsequent algorithm stages should filter for only .tif or .tiff)
+            # Backup original .tif file to .backup file (subsequent algorithm 
+            #   stages should filter for only .tif or .tiff)
             if backup_flag == True:
                 shutil.move(in_raster_path, in_raster_path.split(".")[0] + ".backup")
             out_raster_path = os.path.join(out_tif_directory, f)
-            # Intended to overwrite source file when in_tif_directory = out_tif_directory
-            # If in_tif_directory == out_tif_directory then overwrites original .tif file with offset file so that next stage of ForestMind algorithm can run
+            # If in_tif_directory == out_tif_directory then it overwrites the 
+            #   original .tif file with offset file so that next stage of the
+            #   algorithm can run
+            log.info(f"Moving {out_temporary_raster_path} to {out_raster_path}")
             shutil.move(out_temporary_raster_path, out_raster_path)
-            # Rename file with processing baseline code modified from 0XXX to AXXX to avoid multiple runs of pipeline leading to multiple offsets being applied
+            # Rename file with processing baseline code modified from 0XXX to 
+            #   AXXX to avoid multiple runs of pipeline leading to multiple offsets being applied
             out_raster_path_rename = os.path.join(
                 out_tif_directory,
                 set_processing_baseline(f, "A" + get_processing_baseline(f)[1:]),
             )
+            log.info(f"Moving {out_raster_path} to {out_raster_path_rename}")
             shutil.move(out_raster_path, out_raster_path_rename)
 
-    print("Offsetting Finished")
-    log.info("Offsetting Finished")
+    log.info("Radiometric offsetting of processing baselines > 0400 finished.")
     return out_tif_directory
 
 

--- a/pyeo/raster_manipulation.py
+++ b/pyeo/raster_manipulation.py
@@ -2938,6 +2938,7 @@ def apply_processing_baseline_0400_offset_correction_to_tiff_file_directory(
     bands_to_offset_index=[0, 1, 2, 3],
     BOA_ADD_OFFSET=-1000,
     backup_flag=False,
+    log = logging.getLogger(__name__)
 ):
     """
     Offsets data within selected bands from a directory of stacked raster files
@@ -2957,6 +2958,8 @@ def apply_processing_baseline_0400_offset_correction_to_tiff_file_directory(
         Required offset per band (from xml information within L2A SAFE file directory)
     backup_flag : bool, optional
         If True leaves unoffset images with .backup extension in tif_directory
+    log : logger
+        Directs to the log file
 
     Returns
     -------
@@ -2976,12 +2979,18 @@ def apply_processing_baseline_0400_offset_correction_to_tiff_file_directory(
     if not os.path.exists(out_tif_directory):
         os.mkdir(out_tif_directory)
 
-    #TODO: Force generated dtype to uint16 to save time and storage? Compatible with classifier?
-    # Generate bands_to_offset_index from comparison of bands_to_offset labels in band.description
-    # Read individual BOA_ADD_OFFSET value for each band from xml information in SAFE file root
-    # Use 'with TemporaryDirectory' pattern - Overwrite existing files with offset files by 'move'
-    # Work out why offset files are larger (2GB from ~1GB)
-    print(f"apply_processing_baseline_0400_offset_correction_to_tiff_file_directory() running on: {in_tif_directory}")
+    #TODO: 
+    #  Force generated dtype to uint16 to save time and storage? 
+    #    Compatible with classifier?
+    #  Generate bands_to_offset_index from comparison of bands_to_offset labels
+    #    in band.description
+    #  Read individual BOA_ADD_OFFSET value for each band from xml information
+    #    in SAFE file root
+    #  Work out why offset files are larger (2GB from ~1GB)
+    log.info(f"Radiometric offset correction if processing_baseline > 0400 in" + \
+             " directory: {in_tif_directory}")
+    log.info("NOTE: Processing baseline in the file names will be set to \"A0400\"" + \
+             " if correction has been applied.")
 
     image_files = [
         f
@@ -2989,27 +2998,20 @@ def apply_processing_baseline_0400_offset_correction_to_tiff_file_directory(
         if f.endswith(".tif") or f.endswith(".tiff")
     ]
     for f in image_files:
-        # print(f"File: {f}, Baseline: {get_processing_baseline(f)}")
         log.info(f"File: {f}, Baseline: {get_processing_baseline(f)}")
         if get_processing_baseline(f) == "A400":
-            # print(
-            #     f"Offset already applied - file marked as: {get_processing_baseline(f)}"
-            # )
             log.info(f"Offset already applied - file marked as: {get_processing_baseline(f)}")
         if get_processing_baseline(f) == "0400":
             in_raster_path = os.path.join(in_tif_directory, f)
-            # print(f"Offsetting file: {f}")
             log.info(f"Offsetting file: {f}")
-            # print(f"in_raster_path: {in_raster_path}")
             log.info(f'in_raster_path: {in_raster_path}')
             # Define temporary file destination for output
             out_temporary_raster_path = os.path.join(
                 out_tif_directory,
                 os.path.basename(f).split(".")[0] + "_offset_temp.tif",
             )
-            print(f"out_temporary_raster_path: {out_temporary_raster_path}")
             log.info(f"out_temporary_raster_path: {out_temporary_raster_path}")
-            # Open data set
+            # Open dataset
             in_raster_ds = gdal.Open(in_raster_path, gdal.GA_Update)
             raster_band_count = in_raster_ds.RasterCount
             in_raster_array = in_raster_ds.GetVirtualMemArray()
@@ -3022,10 +3024,8 @@ def apply_processing_baseline_0400_offset_correction_to_tiff_file_directory(
                 eAccess=gdal.GA_Update
             )
 
-            print(f"in_raster_array dtype: {in_raster_array.dtype}")
             log.info(f"in_raster_array dtype: {in_raster_array.dtype}")
             dtype_max = 10000  # np.iinfo(in_raster_array.dtype).max # upper bound for range clipping - should be > any likely pixel value
-            print(f"in_raster_array dtype_max used: {dtype_max}")
             log.info(f"in_raster_array dtype_max used: {dtype_max}")
 
             # Simple offset of all image bands
@@ -3038,7 +3038,8 @@ def apply_processing_baseline_0400_offset_correction_to_tiff_file_directory(
                 + BOA_ADD_OFFSET
             )
 
-            # Untested: Improvement to offset just selected bands by label - for band specific offsetting if required
+            # Untested: Improvement to offset just selected bands by label 
+            #   - for band specific offsetting if required
             # out_raster_array[...] = in_raster_array[...]  # Copy over all data
             # for band_index in raster_band_count:
             #     band_in = in_raster_ds.GetRasterBand(band_index+1)
@@ -3053,24 +3054,27 @@ def apply_processing_baseline_0400_offset_correction_to_tiff_file_directory(
             out_temporary_raster_ds = None
             in_raster_ds = None
 
-            # Backup original .tif file to .backup file (subsequent algorithm stages should filter for only .tif or .tiff)
+            # Backup original .tif file to .backup file (subsequent algorithm 
+            #   stages should filter for only .tif or .tiff)
             if backup_flag == True:
                 shutil.move(in_raster_path, in_raster_path.split(".")[0] + ".backup")
             out_raster_path = os.path.join(out_tif_directory, f)
-            # Intended to overwrite source file when in_tif_directory = out_tif_directory
-            # If in_tif_directory == out_tif_directory then overwrites original .tif file with offset file so that next stage of ForestMind algorithm can run
+            # If in_tif_directory == out_tif_directory then overwrites original 
+            #   .tif file with offset file so that next stage of ForestMind 
+            #   algorithm can run
+            log.info(f"Moving {out_temporary_raster_path} to {out_raster_path}")
             shutil.move(out_temporary_raster_path, out_raster_path)
-            # Rename file with processing baseline code modified from 0400 to A400 to avoid multiple runs of pipeline leading to multiple offsets being applied
+            # Rename file with processing baseline code modified from 0400 to 
+            #   A400 to avoid multiple runs of pipeline leading to multiple 
+            #   offsets being applied
             out_raster_path_rename = os.path.join(
                 out_tif_directory, set_processing_baseline(f, "A400")
             )
+            log.info(f"Moving {out_raster_path} to {out_raster_path_rename}")
             shutil.move(out_raster_path, out_raster_path_rename)
 
-    print("Offsetting Finished")
     log.info("Offsetting Finished")
     return out_tif_directory
-
-
 # Added I.R. 20220607 END
 
 


### PR DESCRIPTION
Two improvements to apps/make_composite.py have been made.
1. Duplicate image acquisition dates with different processing baselines will be filtered in order to only download one image. Preference is given to the Copernicus Space Data Ecosystem version of the L2A image.
2. The number of images for download will be capped AFTER this step, so that the capped number of images of L1C and L2A will be downloaded, and not a number smaller than that if enough images are found.

Runs error-free with the environment_simple.yml Python environment on Linux.